### PR TITLE
feat(onnx): export ChunkFormer encoder/CTC/RNN-T to ONNX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,5 +194,9 @@ data
 raw_wav
 tensorboard
 
+# ONNX export artifacts
+onnx_out/
+*.onnx.data
+
 # Local-only dev parity check (not shipped)
 tools/verify_vipvl_parity.py

--- a/README.md
+++ b/README.md
@@ -1,17 +1,5 @@
 # ChunkFormer: Masked Chunking Conformer For Long-Form Speech Transcription
 ---
-[![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
-[![Paper](https://img.shields.io/badge/Paper-ICASSP%202025-green)](https://arxiv.org/abs/2502.14673)
-
-This repository contains the implementation and supplementary materials for our ICASSP 2025 paper, **"ChunkFormer: Masked Chunking Conformer For Long-Form Speech Transcription"**. The paper has been fully accepted by the reviewers with the highest scores: **4/4/4**.
-
-[![Ranked #1: Speech Recognition on Common Voice Vi](https://img.shields.io/badge/Ranked%20%231%3A%20Speech%20Recognition%20on%20Common%20Voice%20Vi-%F0%9F%8F%86%20SOTA-blueviolet?style=for-the-badge&logo=paperswithcode&logoColor=white)](https://paperswithcode.com/sota/speech-recognition-on-common-voice-vi)
-[![Ranked #1: Speech Recognition on VIVOS](https://img.shields.io/badge/Ranked%20%231%3A%20Speech%20Recognition%20on%20VIVOS-%F0%9F%8F%86%20SOTA-blueviolet?style=for-the-badge&logo=paperswithcode&logoColor=white)](https://paperswithcode.com/sota/speech-recognition-on-vivos)
-
-
-
-https://github.com/user-attachments/assets/aba64174-f965-43f2-92a2-7391fb0dba5c
-
 
 <a name = "updates" ></a>
 ## Updates
@@ -23,6 +11,18 @@ A timeline of model and feature releases (newest first):
 - **2025-11** &mdash; 🗣️ **Speech classification** (gender / emotion / dialect / age): [![Hugging Face](https://img.shields.io/badge/HuggingFace-gender--emotion--dialect--age--classification-orange?logo=huggingface)](https://huggingface.co/khanhld/chunkformer-gender-emotion-dialect-age-classification).
 - **2025-10** &mdash; 🔤 **RNN-T** model released: [![Hugging Face](https://img.shields.io/badge/HuggingFace-chunkformer--rnnt--large--vie-orange?logo=huggingface)](https://huggingface.co/khanhld/chunkformer-rnnt-large-vie).
 - **2025-09** &mdash; 🔡 **CTC** model + training scripts released: [![Hugging Face](https://img.shields.io/badge/HuggingFace-chunkformer--ctc--large--vie-orange?logo=huggingface)](https://huggingface.co/khanhld/chunkformer-ctc-large-vie) (initial `v1.0.0` release).
+---
+[![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
+[![Paper](https://img.shields.io/badge/Paper-ICASSP%202025-green)](https://arxiv.org/abs/2502.14673)
+
+This repository contains the implementation and supplementary materials for our ICASSP 2025 paper, **"ChunkFormer: Masked Chunking Conformer For Long-Form Speech Transcription"**. The paper has been fully accepted by the reviewers with the highest scores: **4/4/4**.
+
+[![Ranked #1: Speech Recognition on Common Voice Vi](https://img.shields.io/badge/Ranked%20%231%3A%20Speech%20Recognition%20on%20Common%20Voice%20Vi-%F0%9F%8F%86%20SOTA-blueviolet?style=for-the-badge&logo=paperswithcode&logoColor=white)](https://paperswithcode.com/sota/speech-recognition-on-common-voice-vi)
+[![Ranked #1: Speech Recognition on VIVOS](https://img.shields.io/badge/Ranked%20%231%3A%20Speech%20Recognition%20on%20VIVOS-%F0%9F%8F%86%20SOTA-blueviolet?style=for-the-badge&logo=paperswithcode&logoColor=white)](https://paperswithcode.com/sota/speech-recognition-on-vivos)
+
+
+
+https://github.com/user-attachments/assets/aba64174-f965-43f2-92a2-7391fb0dba5c
 
 
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -13,7 +13,20 @@ This repository contains the implementation and supplementary materials for our 
 https://github.com/user-attachments/assets/aba64174-f965-43f2-92a2-7391fb0dba5c
 
 
+<a name = "updates" ></a>
+## Updates
+
+A timeline of model and feature releases (newest first):
+
+- **2026-06** &mdash; ⚡ **ONNX export & runtime**. Export the CTC / RNN-T encoders, CTC head, and RNN-T predictor & joint to ONNX (streaming **and** non-streaming), with a self-contained ONNX Runtime inference host and a true online streaming session (incremental audio in → text out). See [`examples/onnx`](examples/onnx/README.md).
+- **2026-06** &mdash; 🧬 **ViP-VL** Vietnamese self-supervised speech encoder released: [![Hugging Face](https://img.shields.io/badge/HuggingFace-vip--vl--base--vie-orange?logo=huggingface)](https://huggingface.co/khanhld/vip-vl-base-vie). See [`examples/ssl/vipvl`](examples/ssl/vipvl/README.md).
+- **2025-11** &mdash; 🗣️ **Speech classification** (gender / emotion / dialect / age): [![Hugging Face](https://img.shields.io/badge/HuggingFace-gender--emotion--dialect--age--classification-orange?logo=huggingface)](https://huggingface.co/khanhld/chunkformer-gender-emotion-dialect-age-classification).
+- **2025-10** &mdash; 🔤 **RNN-T** model released: [![Hugging Face](https://img.shields.io/badge/HuggingFace-chunkformer--rnnt--large--vie-orange?logo=huggingface)](https://huggingface.co/khanhld/chunkformer-rnnt-large-vie).
+- **2025-09** &mdash; 🔡 **CTC** model + training scripts released: [![Hugging Face](https://img.shields.io/badge/HuggingFace-chunkformer--ctc--large--vie-orange?logo=huggingface)](https://huggingface.co/khanhld/chunkformer-ctc-large-vie) (initial `v1.0.0` release).
+
+
 ## Table of Contents
+- [Updates](#updates)
 - [Introduction](#introduction)
 - [Key Features](#key-features)
 - [Installation](#installation)

--- a/chunkformer/modules/attention.py
+++ b/chunkformer/modules/attention.py
@@ -6,6 +6,16 @@ from typing import Optional, Tuple
 import torch
 from torch import nn
 
+from chunkformer.utils.mask import onnx_unfold
+
+
+def _unfold(x: torch.Tensor, dim: int, size: int, step: int) -> torch.Tensor:
+    """Use the ONNX-safe unfold during export/scripting, native unfold (a fast
+    view) otherwise so training/eager behaviour and speed are unchanged."""
+    if torch.jit.is_scripting() or torch.onnx.is_in_onnx_export():
+        return onnx_unfold(x, dim, size, step)
+    return x.unfold(dim, size, step)
+
 
 class MultiHeadedAttention(nn.Module):
     """Multi-Head Attention layer.
@@ -255,6 +265,16 @@ class ChunkAttentionWithRelativeRightContext(MultiHeadedAttention):
         """
         (batch_size, num_heads, time1, n) = x.size()
         time2 = time1 + left_context_size + right_context_size
+        if torch.jit.is_scripting() or torch.onnx.is_in_onnx_export():
+            # ONNX/JIT-friendly relative shift. `as_strided` below uses a
+            # data-dependent `storage_offset` (n_stride * (time1 - 1)) which the
+            # ONNX exporter cannot represent. This gather-based version is
+            # numerically identical: out[..., i, j] = x[..., i, (time1-1)-i+j].
+            q_idx = torch.arange(time1, device=x.device).unsqueeze(1)  # (time1, 1)
+            k_idx = torch.arange(time2, device=x.device).unsqueeze(0)  # (1, time2)
+            idx = ((time1 - 1) - q_idx + k_idx).clamp(0, n - 1)  # (time1, time2)
+            idx = idx.view(1, 1, time1, time2).expand(batch_size, num_heads, time1, time2)
+            return torch.gather(x, 3, idx)
         batch_stride = x.stride(0)
         head_stride = x.stride(1)
         time1_stride = x.stride(2)
@@ -338,7 +358,7 @@ class ChunkAttentionWithRelativeRightContext(MultiHeadedAttention):
             n_frames_pad = n_frames_pad % chunk_size
             q = torch.nn.functional.pad(q, (0, 0, 0, 0, 0, n_frames_pad))
             # [B, n_chunks, head, d_k, q_size]
-            q = q.unfold(1, size=chunk_size, step=chunk_size)
+            q = _unfold(q, 1, chunk_size, chunk_size)
             # [B * n_chunks, head, d_k, q_size]
             q = q.reshape(-1, q.size(2), q.size(3), q.size(4))
             # [B * n_chunks,q_size, head, d_k]
@@ -351,9 +371,7 @@ class ChunkAttentionWithRelativeRightContext(MultiHeadedAttention):
                 kv, (0, 0, left_context_size, n_frames_pad + right_context_size)
             )
             # [B, head, n_chunks, d_k * 2, l + c + r]
-            kv = kv.unfold(
-                2, size=left_context_size + chunk_size + right_context_size, step=chunk_size
-            )
+            kv = _unfold(kv, 2, left_context_size + chunk_size + right_context_size, chunk_size)
             # [B, n_chunks, head, l + c + r, d_k * 2]
             kv = kv.permute(0, 2, 1, 4, 3)
             # [B * n_chunks, head, l + c + r, d_k * 2]
@@ -364,7 +382,7 @@ class ChunkAttentionWithRelativeRightContext(MultiHeadedAttention):
             # [B, 1, T + n_frames_pad]
             mask_q = torch.nn.functional.pad(mask, (0, n_frames_pad))
             # [B, 1, n_chunks, chunk_size]
-            mask_q = mask_q.unfold(-1, size=chunk_size, step=chunk_size)
+            mask_q = _unfold(mask_q, -1, chunk_size, chunk_size)
             # [B *n_chunks, chunk_size]
             mask_q = mask_q.reshape(-1, mask_q.size(-1))
 
@@ -373,8 +391,8 @@ class ChunkAttentionWithRelativeRightContext(MultiHeadedAttention):
                 mask, (left_context_size, n_frames_pad + right_context_size)
             )
             # [B, 1, n_chunks, chunk_size]
-            mask_kv = mask_kv.unfold(
-                -1, size=left_context_size + chunk_size + right_context_size, step=chunk_size
+            mask_kv = _unfold(
+                mask_kv, -1, left_context_size + chunk_size + right_context_size, chunk_size
             )
             # [B, * n_chunks, chunk_size]
             mask_kv = mask_kv.reshape(-1, mask_kv.size(3))

--- a/chunkformer/modules/convolution.py
+++ b/chunkformer/modules/convolution.py
@@ -20,6 +20,8 @@ from typing import Tuple, Union
 import torch
 from torch import nn
 
+from chunkformer.utils.mask import onnx_unfold
+
 
 class ChunkConvolutionModule(nn.Module):
     """ConvolutionModule in ChunkFormer model."""
@@ -119,7 +121,12 @@ class ChunkConvolutionModule(nn.Module):
         """
         # exchange the temporal dimension and the feature dimension
         x = x.transpose(1, 2)  # (#batch, channels, time)
+        bsz = x.size(0)
 
+        # Full-context mode: a single chunk spans the whole (dynamic-length)
+        # sequence, so `size`/`step` below depend on the input length and must
+        # not be baked into the ONNX graph.
+        full_ctx = chunk_size <= 0
         if self.dynamic_conv and chunk_size <= 0:
             chunk_size = x.size(2)
         # mask batch padding
@@ -157,7 +164,18 @@ class ChunkConvolutionModule(nn.Module):
 
             n_chunks = ((x.size(2) - size) // step) + 1
             # [B, C, n_chunks, size]
-            x = x.unfold(-1, size=size, step=step)
+            if torch.jit.is_scripting() or torch.onnx.is_in_onnx_export():
+                # `Tensor.unfold` is not supported by the ONNX exporter.
+                if full_ctx:
+                    # Single chunk over the whole sequence: unfold is just adding
+                    # a chunk axis, and keeps the time dimension dynamic.
+                    x = x.unsqueeze(2)
+                else:
+                    # Fixed-size chunking (limited-context / streaming): use the
+                    # gather-based equivalent (chunk count stays dynamic).
+                    x = onnx_unfold(x, -1, size, step)
+            else:
+                x = x.unfold(-1, size=size, step=step)
             # [B, n_chunks, C, size]
             x = x.transpose(1, 2)
             # [B * n_chunks, C, size]
@@ -171,7 +189,12 @@ class ChunkConvolutionModule(nn.Module):
 
         if self.dynamic_conv:
             # [B, n_chunk, C, chunk_size]
-            x = x.reshape(-1, n_chunks, x.size(1), x.size(2))
+            if torch.jit.is_scripting() or torch.onnx.is_in_onnx_export():
+                # keep n_chunks dynamic for ONNX (variable-length input); the
+                # batch axis is taken from `bsz` captured before chunking.
+                x = x.unflatten(0, (bsz, -1))
+            else:
+                x = x.reshape(-1, n_chunks, x.size(1), x.size(2))
             # [B, C, n_chunks, chunk_size]
             x = x.transpose(1, 2)
             # [B, C, n_chunks * chunk_size]

--- a/chunkformer/onnx/__init__.py
+++ b/chunkformer/onnx/__init__.py
@@ -1,0 +1,29 @@
+"""ONNX export and ONNX Runtime inference for ChunkFormer.
+
+This subpackage provides:
+
+- :mod:`chunkformer.onnx.wrappers`: thin ``nn.Module`` wrappers that expose
+  ONNX-clean (tensor-only) forward signatures for the encoder (streaming and
+  non-streaming), the CTC head, and the RNN-T predictor/joint networks.
+- :mod:`chunkformer.onnx.runtime`: an :class:`OnnxAsrModel` that loads the
+  exported graphs with ONNX Runtime and performs host-side CTC / RNN-T greedy
+  decoding (including the cache-aware streaming chunk loop).
+
+The actual export CLI lives in ``tools/export_onnx.py``.
+"""
+
+from chunkformer.onnx.wrappers import (
+    CtcOnnx,
+    EncoderChunkOnnx,
+    EncoderFullOnnx,
+    JointOnnx,
+    PredictorStepOnnx,
+)
+
+__all__ = [
+    "CtcOnnx",
+    "EncoderChunkOnnx",
+    "EncoderFullOnnx",
+    "JointOnnx",
+    "PredictorStepOnnx",
+]

--- a/chunkformer/onnx/runtime.py
+++ b/chunkformer/onnx/runtime.py
@@ -123,7 +123,8 @@ class OnnxAsrModel:
             energy_floor=0.0,
             sample_frequency=sample_rate,
         )
-        return mat.numpy()[None].astype(np.float32)
+        feats: np.ndarray = mat.numpy()[None].astype(np.float32)
+        return feats
 
     def transcribe_file(self, audio_path: str, streaming: bool = False) -> str:
         """End-to-end: audio file path -> text (self-contained)."""
@@ -370,6 +371,7 @@ class StreamingSession:
 
     # ---------------------------------------------------------------- internals
     def _run_encoder(self, window: np.ndarray) -> np.ndarray:
+        assert self.m.encoder_chunk is not None
         enc_out, self.att_cache, self.cnn_cache = self.m.encoder_chunk.run(
             ["enc_out", "r_att_cache", "r_cnn_cache"],
             {
@@ -380,7 +382,7 @@ class StreamingSession:
             },
         )
         self.offset += self.chunk_size
-        return enc_out
+        return np.asarray(enc_out)
 
     def _decode(self, enc: np.ndarray) -> None:
         if self.is_transducer:
@@ -398,6 +400,7 @@ class StreamingSession:
 
     # --- RNN-T persistent state ------------------------------------------------
     def _init_rnnt_state(self) -> None:
+        assert self.m.predictor is not None and self.m.joint is not None
         n_layers = int(self.m.meta["predictor"]["n_layers"])
         hidden = int(self.m.meta["predictor"]["hidden_size"])
         self._state_m = np.zeros((n_layers, 1, hidden), dtype=np.float32)
@@ -410,6 +413,7 @@ class StreamingSession:
         )
 
     def _decode_rnnt(self, enc: np.ndarray) -> None:
+        assert self.m.predictor is not None and self.m.joint is not None
         for t in range(enc.shape[1]):
             enc_t = enc[:, t : t + 1, :].astype(np.float32)
             per_frame_noblk = 0
@@ -463,5 +467,6 @@ class StreamingSession:
             energy_floor=0.0,
             sample_frequency=self.sr,
         )
+        feats: np.ndarray = mat.numpy().astype(np.float32)
         self._sample_buf = self._sample_buf[n_frames * self._shift :]
-        return mat.numpy().astype(np.float32)
+        return feats

--- a/chunkformer/onnx/runtime.py
+++ b/chunkformer/onnx/runtime.py
@@ -1,0 +1,208 @@
+"""ONNX Runtime inference for exported ChunkFormer models.
+
+Loads the per-submodule ONNX graphs produced by ``tools/export_onnx.py`` and
+runs host-side CTC / RNN-T greedy decoding. The neural network sub-graphs run in
+ONNX Runtime; all search/loop logic stays in Python (mirroring
+``chunkformer.modules.search`` and ``chunkformer.transducer.search``).
+"""
+
+import json
+import os
+from typing import Dict, List, Optional
+
+import numpy as np
+
+try:
+    import onnxruntime as ort
+except ImportError as e:  # pragma: no cover - optional dependency
+    raise ImportError(
+        "onnxruntime is required for chunkformer.onnx.runtime. "
+        "Install it with `pip install onnxruntime` (or the [onnx] extra)."
+    ) from e
+
+
+def _providers(device: str) -> List[str]:
+    if device == "cuda":
+        return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    return ["CPUExecutionProvider"]
+
+
+def remove_duplicates_and_blank(hyp: List[int], blank_id: int = 0) -> List[int]:
+    """CTC collapse: merge repeats then drop blanks."""
+    out: List[int] = []
+    prev = -1
+    for tok in hyp:
+        if tok != prev:
+            if tok != blank_id:
+                out.append(tok)
+            prev = tok
+    return out
+
+
+class OnnxAsrModel:
+    """Run an exported ChunkFormer model with ONNX Runtime.
+
+    Args:
+        model_dir: directory containing the exported ``*.onnx`` graphs and
+            ``onnx_config.json``.
+        device: ``"cpu"`` or ``"cuda"``.
+        char_dict: optional ``{id: token}`` map for producing text output.
+    """
+
+    def __init__(
+        self,
+        model_dir: str,
+        device: str = "cpu",
+        char_dict: Optional[Dict[int, str]] = None,
+    ):
+        self.model_dir = model_dir
+        self.device = device
+        with open(os.path.join(model_dir, "onnx_config.json"), "r", encoding="utf-8") as f:
+            self.meta = json.load(f)
+        self.blank_id = int(self.meta.get("blank_id", 0))
+        self.char_dict = char_dict
+        providers = _providers(device)
+
+        def _load(name: str) -> Optional[ort.InferenceSession]:
+            path = os.path.join(model_dir, name)
+            if not os.path.exists(path):
+                return None
+            return ort.InferenceSession(path, providers=providers)
+
+        self.encoder_full = _load("encoder_full.onnx")
+        self.encoder_chunk = _load("encoder_chunk.onnx")
+        self.ctc = _load("ctc.onnx")
+        self.predictor = _load("predictor.onnx")
+        self.joint = _load("joint.onnx")
+
+    # ------------------------------------------------------------------ encoder
+    def encode_full(self, feats: np.ndarray, feat_lens: np.ndarray):
+        """Full-context encoder. feats: (B, T, F) float32."""
+        assert self.encoder_full is not None, "encoder_full.onnx not found"
+        enc_out, enc_lens = self.encoder_full.run(
+            ["enc_out", "enc_lens"],
+            {"feats": feats.astype(np.float32), "feat_lens": feat_lens.astype(np.int64)},
+        )
+        return enc_out, enc_lens
+
+    def encode_streaming(self, feats: np.ndarray):
+        """Cache-aware streaming encoder over a single utterance.
+
+        feats: (1, T, F) float32. Mirrors ``encoder.forward_chunk_by_chunk``.
+        Returns enc_out (1, T', D).
+        """
+        assert self.encoder_chunk is not None, "encoder_chunk.onnx not found"
+        stream = self.meta["stream"]
+        chunk_size = stream["chunk_size"]
+        left = stream["left_context_size"]
+        size = stream["size"]
+        stride = stream["stride"]
+        num_blocks = self.meta["num_blocks"]
+        heads = self.meta["attention_heads"]
+        d_out = self.meta["encoder_output_size"]
+        conv_lorder = self.meta["cnn_lorder"]
+
+        x = feats.astype(np.float32)
+        # pad so the last window is complete (mirrors forward_chunk_by_chunk)
+        t = x.shape[1]
+        if t >= size:
+            pad = (stride - ((t - size) % stride)) % stride
+        else:
+            pad = size - t
+        if pad > 0:
+            x = np.pad(x, ((0, 0), (0, pad), (0, 0)))
+
+        att_cache = np.zeros((num_blocks, 1, heads, left, d_out // heads * 2), dtype=np.float32)
+        cnn_cache = np.zeros((num_blocks, 1, d_out, conv_lorder), dtype=np.float32)
+
+        outs = []
+        offset = 0
+        total = x.shape[1]
+        for i in range(0, total - size + stride, stride):
+            chunk = x[:, i : i + size, :]
+            enc_out, att_cache, cnn_cache = self.encoder_chunk.run(
+                ["enc_out", "r_att_cache", "r_cnn_cache"],
+                {
+                    "chunk": chunk,
+                    "att_cache": att_cache,
+                    "cnn_cache": cnn_cache,
+                    "offset": np.array(offset, dtype=np.int64),
+                },
+            )
+            if i + size < total:
+                enc_out = enc_out[:, :chunk_size, :]
+            outs.append(enc_out)
+            offset += chunk_size
+        return np.concatenate(outs, axis=1)
+
+    # --------------------------------------------------------------------- CTC
+    def ctc_logprobs(self, enc_out: np.ndarray) -> np.ndarray:
+        assert self.ctc is not None, "ctc.onnx not found"
+        (log_probs,) = self.ctc.run(["log_probs"], {"enc_out": enc_out.astype(np.float32)})
+        return np.asarray(log_probs)
+
+    def ctc_greedy(self, enc_out: np.ndarray, enc_len: int) -> List[int]:
+        log_probs = self.ctc_logprobs(enc_out)[0][:enc_len]
+        hyp = log_probs.argmax(axis=-1).tolist()
+        return remove_duplicates_and_blank(hyp, self.blank_id)
+
+    # ------------------------------------------------------------------- RNN-T
+    def rnnt_greedy(self, enc_out: np.ndarray, enc_len: int, n_steps: int = 64) -> List[int]:
+        """Single-utterance RNN-T greedy search (mirrors basic_greedy_search)."""
+        assert self.predictor is not None and self.joint is not None
+        n_layers = self.meta["predictor"]["n_layers"]
+        hidden = self.meta["predictor"]["hidden_size"]
+
+        state_m = np.zeros((n_layers, 1, hidden), dtype=np.float32)
+        state_c = np.zeros((n_layers, 1, hidden), dtype=np.float32)
+        token = np.array([[self.blank_id]], dtype=np.int64)
+
+        pred_out, new_m, new_c = self.predictor.run(
+            ["pred_out", "new_m", "new_c"],
+            {"token": token, "state_m": state_m, "state_c": state_c},
+        )
+
+        hyps: List[int] = []
+        t = 0
+        prev_nblk = True
+        per_frame_noblk = 0
+        while t < enc_len:
+            enc_t = enc_out[:, t : t + 1, :].astype(np.float32)
+            if prev_nblk:
+                pred_out, new_m, new_c = self.predictor.run(
+                    ["pred_out", "new_m", "new_c"],
+                    {"token": token, "state_m": state_m, "state_c": state_c},
+                )
+            (logits,) = self.joint.run(["logits"], {"enc_t": enc_t, "pred": pred_out})
+            best = int(logits.reshape(-1).argmax())
+            if best != self.blank_id:
+                hyps.append(best)
+                prev_nblk = True
+                per_frame_noblk += 1
+                token = np.array([[best]], dtype=np.int64)
+                state_m, state_c = new_m, new_c
+            if best == self.blank_id or per_frame_noblk >= n_steps:
+                prev_nblk = best != self.blank_id
+                t += 1
+                per_frame_noblk = 0
+        return hyps
+
+    # ------------------------------------------------------------------- decode
+    def tokens_to_text(self, tokens: List[int]) -> str:
+        if self.char_dict is None:
+            return " ".join(str(t) for t in tokens)
+        pieces = [self.char_dict.get(t, "") for t in tokens]
+        return "".join(pieces).replace("\u2581", " ").strip()
+
+    def transcribe(self, feats: np.ndarray, feat_lens: np.ndarray, streaming: bool = False) -> str:
+        if streaming:
+            enc_out = self.encode_streaming(feats)
+            enc_len = enc_out.shape[1]
+        else:
+            enc_out, enc_lens = self.encode_full(feats, feat_lens)
+            enc_len = int(enc_lens[0])
+        if self.meta.get("is_transducer"):
+            tokens = self.rnnt_greedy(enc_out, enc_len)
+        else:
+            tokens = self.ctc_greedy(enc_out, enc_len)
+        return self.tokens_to_text(tokens)

--- a/chunkformer/onnx/runtime.py
+++ b/chunkformer/onnx/runtime.py
@@ -60,6 +60,10 @@ class OnnxAsrModel:
         with open(os.path.join(model_dir, "onnx_config.json"), "r", encoding="utf-8") as f:
             self.meta = json.load(f)
         self.blank_id = int(self.meta.get("blank_id", 0))
+        # Fall back to the vocab.txt written next to the graphs so text output
+        # needs no external files / no PyTorch model.
+        if char_dict is None:
+            char_dict = self._load_vocab(os.path.join(model_dir, "vocab.txt"))
         self.char_dict = char_dict
         providers = _providers(device)
 
@@ -74,6 +78,58 @@ class OnnxAsrModel:
         self.ctc = _load("ctc.onnx")
         self.predictor = _load("predictor.onnx")
         self.joint = _load("joint.onnx")
+
+    @staticmethod
+    def _load_vocab(path: str) -> Optional[Dict[int, str]]:
+        """Read a ``token id`` per-line vocab file into ``{id: token}``."""
+        if not os.path.exists(path):
+            return None
+        char_dict: Dict[int, str] = {}
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                arr = line.strip().split()
+                if len(arr) == 2:
+                    char_dict[int(arr[1])] = arr[0]
+        return char_dict or None
+
+    # -------------------------------------------------------------- features
+    def extract_features(self, audio_path: str) -> np.ndarray:
+        """Waveform -> raw fbank (B=1, T, F) float32, matching the PyTorch model.
+
+        CMVN is baked into the encoder graph, so no normalisation is applied
+        here. Requires ``torch``/``torchaudio`` and ``pydub`` (lazy-imported).
+        """
+        try:
+            import torch
+            import torchaudio.compliance.kaldi as kaldi
+            from pydub import AudioSegment
+        except ImportError as e:  # pragma: no cover - optional deps
+            raise ImportError(
+                "extract_features needs torch, torchaudio and pydub. Either install "
+                "them, or pass pre-computed fbank features to transcribe()/encode_*()."
+            ) from e
+
+        feat = self.meta.get("feature", {})
+        sample_rate = int(feat.get("sample_rate", 16000))
+        audio = AudioSegment.from_file(audio_path)
+        audio = audio.set_frame_rate(sample_rate).set_sample_width(2).set_channels(1)
+        waveform = torch.as_tensor(audio.get_array_of_samples(), dtype=torch.float32).unsqueeze(0)
+        mat = kaldi.fbank(
+            waveform,
+            num_mel_bins=int(feat.get("num_mel_bins", self.meta["feat_dim"])),
+            frame_length=int(feat.get("frame_length", 25)),
+            frame_shift=int(feat.get("frame_shift", 10)),
+            dither=0.0,
+            energy_floor=0.0,
+            sample_frequency=sample_rate,
+        )
+        return mat.numpy()[None].astype(np.float32)
+
+    def transcribe_file(self, audio_path: str, streaming: bool = False) -> str:
+        """End-to-end: audio file path -> text (self-contained)."""
+        feats = self.extract_features(audio_path)
+        feat_lens = np.array([feats.shape[1]], dtype=np.int64)
+        return self.transcribe(feats, feat_lens, streaming=streaming)
 
     # ------------------------------------------------------------------ encoder
     def encode_full(self, feats: np.ndarray, feat_lens: np.ndarray):

--- a/chunkformer/onnx/runtime.py
+++ b/chunkformer/onnx/runtime.py
@@ -262,3 +262,206 @@ class OnnxAsrModel:
         else:
             tokens = self.ctc_greedy(enc_out, enc_len)
         return self.tokens_to_text(tokens)
+
+    # ----------------------------------------------------------------- streaming
+    def stream(self, n_steps: int = 64) -> "StreamingSession":
+        """Open a stateful online streaming session.
+
+        Feed audio incrementally with ``push_waveform`` / ``push_features`` and
+        get the text decoded so far for each push; call ``finalize`` to flush.
+        Manages the encoder caches (CTC and RNN-T) and, for RNN-T, the predictor
+        LSTM state across chunks. Requires a ``--streaming`` export.
+        """
+        return StreamingSession(self, n_steps=n_steps)
+
+
+class StreamingSession:
+    """Online, cache-aware streaming decode for one utterance.
+
+    Audio (or pre-computed fbank) is pushed incrementally. Internally it:
+
+    * extracts fbank frames online (sample buffer with kaldi snip-edges framing),
+    * runs ``encoder_chunk.onnx`` once per ``size``-frame window, threading the
+      attention and convolution caches plus the warm-up ``offset``,
+    * decodes the newly finalized encoder frames with CTC or RNN-T greedy search,
+      carrying the CTC repeat-merge state or the RNN-T predictor LSTM state and
+      last emitted token across chunks.
+
+    Each ``push_*`` / ``finalize`` returns the *delta* text produced by that call.
+    The full hypothesis is available via ``.text`` and ``.tokens``.
+    """
+
+    def __init__(self, model: OnnxAsrModel, n_steps: int = 64):
+        if model.encoder_chunk is None or "stream" not in model.meta:
+            raise ValueError(
+                "StreamingSession requires a streaming export (run export_onnx.py "
+                "with --streaming)."
+            )
+        self.m = model
+        self.n_steps = n_steps
+        stream = model.meta["stream"]
+        self.chunk_size = int(stream["chunk_size"])
+        self.left = int(stream["left_context_size"])
+        self.size = int(stream["size"])
+        self.stride = int(stream["stride"])
+
+        nb = int(model.meta["num_blocks"])
+        heads = int(model.meta["attention_heads"])
+        d_out = int(model.meta["encoder_output_size"])
+        lorder = int(model.meta["cnn_lorder"])
+        self.att_cache = np.zeros((nb, 1, heads, self.left, d_out // heads * 2), dtype=np.float32)
+        self.cnn_cache = np.zeros((nb, 1, d_out, lorder), dtype=np.float32)
+        self.offset = 0
+        self.is_transducer = bool(model.meta.get("is_transducer"))
+
+        # feature-extraction (online fbank) state
+        feat = model.meta.get("feature", {})
+        self.sr = int(feat.get("sample_rate", 16000))
+        self.num_mel_bins = int(feat.get("num_mel_bins", model.meta["feat_dim"]))
+        self.frame_length_ms = int(feat.get("frame_length", 25))
+        self.frame_shift_ms = int(feat.get("frame_shift", 10))
+        self._win = int(round(self.sr * self.frame_length_ms / 1000))
+        self._shift = int(round(self.sr * self.frame_shift_ms / 1000))
+        self._sample_buf = np.zeros(0, dtype=np.float32)
+        self._feat_buf = np.zeros((0, model.meta["feat_dim"]), dtype=np.float32)
+
+        # decode state
+        self.tokens: List[int] = []
+        self._ctc_prev = -1  # last argmax id, for cross-chunk CTC repeat-merge
+        if self.is_transducer:
+            self._init_rnnt_state()
+
+    # -------------------------------------------------------------- public API
+    @property
+    def text(self) -> str:
+        return self.m.tokens_to_text(self.tokens)
+
+    def push_features(self, frames: np.ndarray) -> str:
+        """Push raw fbank frames (n, F). Returns the delta text."""
+        prev = self.text
+        if frames is not None and frames.shape[0] > 0:
+            self._feat_buf = np.concatenate([self._feat_buf, frames.astype(np.float32)], axis=0)
+        while self._feat_buf.shape[0] >= self.size:
+            window = self._feat_buf[: self.size][None]
+            enc = self._run_encoder(window)[:, : self.chunk_size, :]
+            self._decode(enc)
+            self._feat_buf = self._feat_buf[self.stride :]
+        return self.text[len(prev) :]
+
+    def push_waveform(self, samples: np.ndarray) -> str:
+        """Push int16-range PCM samples (1-D). Returns the delta text.
+
+        Mirrors the offline extractor: raw int16 sample values, no normalisation,
+        kaldi snip-edges framing. Requires torch/torchaudio.
+        """
+        return self.push_features(self._samples_to_features(samples))
+
+    def finalize(self) -> str:
+        """Flush the remaining buffered frames as the final (padded) window."""
+        prev = self.text
+        if self._feat_buf.shape[0] > 0:
+            window = self._feat_buf
+            if window.shape[0] < self.size:
+                window = np.pad(window, ((0, self.size - window.shape[0]), (0, 0)))
+            enc = self._run_encoder(window[None])  # keep all frames on the last window
+            self._decode(enc)
+            self._feat_buf = self._feat_buf[:0]
+        return self.text[len(prev) :]
+
+    # ---------------------------------------------------------------- internals
+    def _run_encoder(self, window: np.ndarray) -> np.ndarray:
+        enc_out, self.att_cache, self.cnn_cache = self.m.encoder_chunk.run(
+            ["enc_out", "r_att_cache", "r_cnn_cache"],
+            {
+                "chunk": window.astype(np.float32),
+                "att_cache": self.att_cache,
+                "cnn_cache": self.cnn_cache,
+                "offset": np.array(self.offset, dtype=np.int64),
+            },
+        )
+        self.offset += self.chunk_size
+        return enc_out
+
+    def _decode(self, enc: np.ndarray) -> None:
+        if self.is_transducer:
+            self._decode_rnnt(enc)
+        else:
+            self._decode_ctc(enc)
+
+    def _decode_ctc(self, enc: np.ndarray) -> None:
+        log_probs = self.m.ctc_logprobs(enc)[0]  # (T, V)
+        for tok in log_probs.argmax(axis=-1).tolist():
+            if tok != self._ctc_prev:
+                if tok != self.m.blank_id:
+                    self.tokens.append(int(tok))
+                self._ctc_prev = tok
+
+    # --- RNN-T persistent state ------------------------------------------------
+    def _init_rnnt_state(self) -> None:
+        n_layers = int(self.m.meta["predictor"]["n_layers"])
+        hidden = int(self.m.meta["predictor"]["hidden_size"])
+        self._state_m = np.zeros((n_layers, 1, hidden), dtype=np.float32)
+        self._state_c = np.zeros((n_layers, 1, hidden), dtype=np.float32)
+        self._token = np.array([[self.m.blank_id]], dtype=np.int64)
+        self._prev_nblk = True
+        self._pred_out, self._cand_m, self._cand_c = self.m.predictor.run(
+            ["pred_out", "new_m", "new_c"],
+            {"token": self._token, "state_m": self._state_m, "state_c": self._state_c},
+        )
+
+    def _decode_rnnt(self, enc: np.ndarray) -> None:
+        for t in range(enc.shape[1]):
+            enc_t = enc[:, t : t + 1, :].astype(np.float32)
+            per_frame_noblk = 0
+            while True:
+                if self._prev_nblk:
+                    self._pred_out, self._cand_m, self._cand_c = self.m.predictor.run(
+                        ["pred_out", "new_m", "new_c"],
+                        {
+                            "token": self._token,
+                            "state_m": self._state_m,
+                            "state_c": self._state_c,
+                        },
+                    )
+                (logits,) = self.m.joint.run(["logits"], {"enc_t": enc_t, "pred": self._pred_out})
+                best = int(logits.reshape(-1).argmax())
+                if best != self.m.blank_id:
+                    self.tokens.append(best)
+                    self._prev_nblk = True
+                    per_frame_noblk += 1
+                    self._token = np.array([[best]], dtype=np.int64)
+                    self._state_m, self._state_c = self._cand_m, self._cand_c
+                if best == self.m.blank_id or per_frame_noblk >= self.n_steps:
+                    self._prev_nblk = best != self.m.blank_id
+                    break
+
+    # --- online fbank ----------------------------------------------------------
+    def _samples_to_features(self, samples: np.ndarray) -> np.ndarray:
+        try:
+            import torch
+            import torchaudio.compliance.kaldi as kaldi
+        except ImportError as e:  # pragma: no cover - optional deps
+            raise ImportError(
+                "push_waveform needs torch and torchaudio. Use push_features with "
+                "pre-computed fbank for a torch-free deployment."
+            ) from e
+
+        self._sample_buf = np.concatenate(
+            [self._sample_buf, np.asarray(samples, dtype=np.float32).reshape(-1)]
+        )
+        if self._sample_buf.shape[0] < self._win:
+            return np.zeros((0, self._feat_buf.shape[1]), dtype=np.float32)
+        n_frames = 1 + (self._sample_buf.shape[0] - self._win) // self._shift
+        end = (n_frames - 1) * self._shift + self._win
+        wav = torch.from_numpy(self._sample_buf[:end].copy()).float().unsqueeze(0)
+        mat = kaldi.fbank(
+            wav,
+            num_mel_bins=self.num_mel_bins,
+            frame_length=self.frame_length_ms,
+            frame_shift=self.frame_shift_ms,
+            dither=0.0,
+            energy_floor=0.0,
+            sample_frequency=self.sr,
+        )
+        self._sample_buf = self._sample_buf[n_frames * self._shift :]
+        return mat.numpy().astype(np.float32)

--- a/chunkformer/onnx/wrappers.py
+++ b/chunkformer/onnx/wrappers.py
@@ -1,0 +1,185 @@
+"""ONNX-clean ``nn.Module`` wrappers around ChunkFormer submodules.
+
+Each wrapper exposes a ``forward`` that takes and returns only plain tensors
+(no dicts, lists, ``Optional`` or python-int control flow that depends on the
+data), which is the form ``torch.onnx.export`` handles reliably.
+
+The streaming encoder bakes ``chunk_size`` / ``left_context_size`` /
+``right_context_size`` as python ints at construction time (so the traced graph
+is specialised for one streaming configuration) while keeping ``offset`` as a
+tensor input so the warm-up masking for the first chunks is computed correctly
+inside the graph.
+"""
+
+from typing import Tuple
+
+import torch
+
+
+def _disable_subsampling_conv_chunking(encoder: torch.nn.Module) -> None:
+    """Force the simple ``self.conv(x)`` path in the subsampling module.
+
+    The depthwise-striding subsampling has a data-dependent ``need_to_split``
+    branch (guarded by ``subsampling_conv_chunking_factor``) used to work around
+    a 2**31 element indexing limit for very large batches. Setting the factor to
+    ``-1`` skips that branch entirely, which keeps the exported ONNX graph clean
+    and is always correct for the (small) tensors used at inference time.
+    """
+    if hasattr(encoder, "embed") and hasattr(encoder.embed, "subsampling_conv_chunking_factor"):
+        encoder.embed.subsampling_conv_chunking_factor = -1
+
+
+class EncoderFullOnnx(torch.nn.Module):
+    """Non-streaming encoder.
+
+    Supports both full-context decoding (``chunk_size=0``) and ChunkFormer's
+    masked limited-context decoding (``chunk_size>0`` with left/right context),
+    which is the efficient long-form mode. The context sizes are baked in at
+    construction; ``chunk_size=0`` means full context.
+
+    Inputs:
+        feats: (B, T, feat_dim) raw fbank features (CMVN is applied internally).
+        feat_lens: (B,) int lengths in frames.
+    Outputs:
+        enc_out: (B, T', D) encoder output.
+        enc_lens: (B,) int output lengths.
+    """
+
+    def __init__(
+        self,
+        encoder: torch.nn.Module,
+        chunk_size: int = 0,
+        left_context_size: int = 0,
+        right_context_size: int = 0,
+    ):
+        super().__init__()
+        _disable_subsampling_conv_chunking(encoder)
+        self.encoder = encoder
+        self.chunk_size = int(chunk_size)
+        self.left_context_size = int(left_context_size)
+        self.right_context_size = int(right_context_size)
+
+    def forward(
+        self, feats: torch.Tensor, feat_lens: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        enc_out, masks = self.encoder.forward_encoder(  # type: ignore[operator]
+            feats,
+            feat_lens,
+            chunk_size=self.chunk_size,
+            left_context_size=self.left_context_size,
+            right_context_size=self.right_context_size,
+        )
+        enc_lens = masks.squeeze(1).sum(1).to(torch.int64)
+        return enc_out, enc_lens
+
+
+class EncoderChunkOnnx(torch.nn.Module):
+    """Cache-aware streaming encoder for a single chunk.
+
+    ``chunk_size`` / ``left_context_size`` / ``right_context_size`` are baked in
+    at construction. Inputs:
+        chunk: (B, T_chunk, feat_dim) raw fbank features for one window of
+            ``size = reverse_calc_length(chunk_size) + right_context_size * sub``
+            frames.
+        att_cache: (num_blocks, B, heads, left_context_size, 2*d_k).
+        cnn_cache: (num_blocks, B, D, cnn_module_kernel//2).
+        offset: scalar int64 tensor, number of already-emitted subsampled frames.
+    Outputs:
+        enc_out: (B, chunk_size(+right at tail), D).
+        r_att_cache / r_cnn_cache: updated caches with the same shapes as inputs.
+    """
+
+    def __init__(
+        self,
+        encoder: torch.nn.Module,
+        chunk_size: int,
+        left_context_size: int,
+        right_context_size: int,
+    ):
+        super().__init__()
+        _disable_subsampling_conv_chunking(encoder)
+        self.encoder = encoder
+        self.chunk_size = int(chunk_size)
+        self.left_context_size = int(left_context_size)
+        self.right_context_size = int(right_context_size)
+
+    def forward(
+        self,
+        chunk: torch.Tensor,
+        att_cache: torch.Tensor,
+        cnn_cache: torch.Tensor,
+        offset: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        enc_out, _, r_att_cache, r_cnn_cache = self.encoder.forward_chunk(  # type: ignore[operator]
+            chunk,
+            att_cache=att_cache,
+            cnn_cache=cnn_cache,
+            chunk_size=self.chunk_size,
+            left_context_size=self.left_context_size,
+            right_context_size=self.right_context_size,
+            offset=offset,
+        )
+        return enc_out, r_att_cache, r_cnn_cache
+
+
+class CtcOnnx(torch.nn.Module):
+    """CTC head: encoder output -> log-probabilities.
+
+    Inputs:
+        enc_out: (B, T, D).
+    Outputs:
+        log_probs: (B, T, V).
+    """
+
+    def __init__(self, ctc: torch.nn.Module):
+        super().__init__()
+        self.ctc = ctc
+
+    def forward(self, enc_out: torch.Tensor) -> torch.Tensor:
+        out: torch.Tensor = self.ctc.log_softmax(enc_out)  # type: ignore[operator]
+        return out
+
+
+class PredictorStepOnnx(torch.nn.Module):
+    """RNN-T predictor single step (LSTM with explicit state cache).
+
+    Inputs:
+        token: (B, 1) int64 previous token id.
+        state_m: (num_layers, B, hidden) LSTM hidden state.
+        state_c: (num_layers, B, hidden) LSTM cell state.
+    Outputs:
+        pred_out: (B, 1, P) predictor projection.
+        new_m / new_c: updated LSTM states.
+    """
+
+    def __init__(self, predictor: torch.nn.Module):
+        super().__init__()
+        self.predictor = predictor
+
+    def forward(
+        self, token: torch.Tensor, state_m: torch.Tensor, state_c: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        embed = self.predictor.dropout(self.predictor.embed(token))  # type: ignore[operator]
+        states = (state_m, state_c)
+        pred_out, (new_m, new_c) = self.predictor.rnn(embed, states)  # type: ignore[operator]
+        pred_out = self.predictor.projection(pred_out)  # type: ignore[operator]
+        return pred_out, new_m, new_c
+
+
+class JointOnnx(torch.nn.Module):
+    """RNN-T joint network.
+
+    Inputs:
+        enc_t: (B, 1, E) encoder output for one frame.
+        pred: (B, 1, P) predictor output for one step.
+    Outputs:
+        logits: (B, 1, V) joint logits (no log_softmax; matches PyTorch joint).
+    """
+
+    def __init__(self, joint: torch.nn.Module):
+        super().__init__()
+        self.joint = joint
+
+    def forward(self, enc_t: torch.Tensor, pred: torch.Tensor) -> torch.Tensor:
+        out: torch.Tensor = self.joint(enc_t, pred)  # type: ignore[operator]
+        return out

--- a/chunkformer/utils/mask.py
+++ b/chunkformer/utils/mask.py
@@ -18,6 +18,28 @@ from typing import Optional, Tuple
 import numpy as np
 import torch
 
+
+def onnx_unfold(x: torch.Tensor, dim: int, size: int, step: int) -> torch.Tensor:
+    """ONNX/JIT-friendly equivalent of ``Tensor.unfold(dim, size, step)``.
+
+    ``Tensor.unfold`` is not supported by the ONNX exporter. This gather-based
+    version produces an identical result (the unfolded ``dim`` is replaced by the
+    number of windows and a window axis of length ``size`` is appended last) while
+    keeping the number-of-windows dimension dynamic via ``unflatten(dim, (-1,
+    size))`` so the exported graph supports variable-length inputs.
+    """
+    dim = dim % x.dim()
+    length = x.size(dim)
+    n = (length - size) // step + 1
+    starts = torch.arange(n, device=x.device) * step  # (n,)
+    offs = torch.arange(size, device=x.device)  # (size,)
+    idx = (starts.unsqueeze(1) + offs.unsqueeze(0)).reshape(-1)  # (n * size,)
+    out = x.index_select(dim, idx)
+    out = out.unflatten(dim, (-1, size))
+    out = out.movedim(dim + 1, out.dim() - 1)
+    return out
+
+
 '''
 def subsequent_mask(
         size: int,

--- a/examples/onnx/README.md
+++ b/examples/onnx/README.md
@@ -103,6 +103,43 @@ asr.transcribe(feats, np.array([feats.shape[1]], dtype=np.int64))
 - `transcribe_file(...)` additionally needs `torch`, `torchaudio` and `pydub`
   for waveform -> fbank extraction.
 
+## Online (real-time) streaming
+
+For a `--streaming` export, `OnnxAsrModel.stream()` opens a stateful
+`StreamingSession`: push audio as it arrives and get the text decoded so far for
+each push. It manages **all** the streaming caches — the encoder attention/conv
+caches + warm-up offset (used by both CTC and RNN-T), and for RNN-T the predictor
+LSTM state and last emitted token across chunks.
+
+```python
+from chunkformer.onnx.runtime import OnnxAsrModel
+
+asr = OnnxAsrModel("onnx_out/rnnt_stream")
+sess = asr.stream()
+
+for samples in mic_chunks():          # 1-D int16-range PCM (any chunk size)
+    delta = sess.push_waveform(samples)
+    if delta:
+        print(delta, end="", flush=True)
+print(sess.finalize())                # flush the tail
+# sess.text / sess.tokens hold the full hypothesis
+```
+
+- `push_waveform(samples)` buffers audio, extracts fbank online (kaldi
+  snip-edges framing), runs one encoder window per `size` frames and decodes the
+  newly finalized frames. Returns the *delta* text from that push.
+- `push_features(frames)` is the torch-free variant — push pre-computed raw
+  fbank `(n, F)` yourself; only `numpy` + `onnxruntime` are needed.
+- `finalize()` flushes the remaining buffered frames as the final window.
+
+Verify the online session matches the offline streaming path (online vs offline
+fbank, and identical transcripts for both RNN-T and the CTC-only cache path):
+
+```bash
+python tools/verify_streaming_session.py --onnx-dir onnx_out/rnnt_stream \
+    --audio samples/audios/audio_1.wav
+```
+
 ## Verify parity
 
 `tools/verify_onnx_parity.py` reports the max absolute difference between each

--- a/examples/onnx/README.md
+++ b/examples/onnx/README.md
@@ -67,24 +67,41 @@ The time dimension stays dynamic, so one graph handles variable-length audio.
 
 ## Inference
 
+The export folder is **self-contained** — it ships the `*.onnx` graphs, the
+vocabulary (`vocab.txt`) and the feature config (`onnx_config.json`). A new user
+needs only the folder; the PyTorch model is **not** required at inference time.
+
 ```python
-import numpy as np
-from chunkformer.chunkformer_model import ChunkFormerModel
 from chunkformer.onnx.runtime import OnnxAsrModel
 
-# char_dict (id -> token) for text output; reuse the PyTorch model's table
-pt = ChunkFormerModel.from_pretrained("khanhld/chunkformer-ctc-large-vie")
-feats, flen = pt._load_audio_and_extract_features("samples/audios/audio_1.wav")
-
-onnx = OnnxAsrModel("onnx_out/ctc", device="cpu", char_dict=pt.char_dict)
-text = onnx.transcribe(
-    feats.unsqueeze(0).numpy(), np.array([flen], dtype=np.int64), streaming=False
-)
-print(text)
+# vocab.txt is auto-loaded from the export dir, so text output works out of the box
+asr = OnnxAsrModel("onnx_out/ctc", device="cpu")   # device="cuda" for GPU
+print(asr.transcribe_file("samples/audios/audio_1.wav"))
 ```
 
 For a streaming model, pass `streaming=True` (the runtime runs the cache-aware
-chunk loop using the parameters stored in `onnx_config.json`).
+chunk loop using the parameters stored in `onnx_config.json`):
+
+```python
+asr = OnnxAsrModel("onnx_out/rnnt_stream")
+print(asr.transcribe_file("samples/audios/audio_1.wav", streaming=True))
+```
+
+`transcribe_file` extracts fbank features with `torchaudio` + `pydub` (CMVN is
+baked into the encoder graph). If you already have features, or want a pure
+`numpy`/`onnxruntime` deployment without torch, feed them directly:
+
+```python
+import numpy as np
+feats = np.load("feats.npy")[None]               # (1, T, F) float32 raw fbank
+asr.transcribe(feats, np.array([feats.shape[1]], dtype=np.int64))
+```
+
+### Requirements
+
+- `transcribe(...)` / `encode_*` need only `onnxruntime` + `numpy`.
+- `transcribe_file(...)` additionally needs `torch`, `torchaudio` and `pydub`
+  for waveform -> fbank extraction.
 
 ## Verify parity
 

--- a/examples/onnx/README.md
+++ b/examples/onnx/README.md
@@ -1,0 +1,121 @@
+# ChunkFormer ONNX Export & Inference
+
+Export ChunkFormer ASR models (CTC and RNN-T) to standalone ONNX graphs and run
+them with ONNX Runtime. Both **full-context** (non-streaming) and **cache-aware
+streaming** encoder paths are supported. Search/decoding loops stay in host
+Python; only the neural-network sub-graphs run in ONNX.
+
+## Install
+
+```bash
+pip install -e ".[onnx]"        # adds onnx, onnxruntime, onnxsim
+# or, for GPU inference:  pip install onnxruntime-gpu
+```
+
+## Exported graphs
+
+`tools/export_onnx.py` writes one ONNX file per submodule plus an
+`onnx_config.json` with the shapes/metadata the runtime needs:
+
+| File | Module | Inputs | Outputs |
+|---|---|---|---|
+| `encoder_full.onnx` | full-context encoder | `feats[B,T,80]`, `feat_lens[B]` | `enc_out[B,T',D]`, `enc_lens[B]` |
+| `encoder_chunk.onnx` | streaming encoder (`--streaming`) | `chunk`, `att_cache`, `cnn_cache`, `offset` | `enc_out`, `r_att_cache`, `r_cnn_cache` |
+| `ctc.onnx` | CTC head | `enc_out[B,T,D]` | `log_probs[B,T,V]` |
+| `predictor.onnx` | RNN-T predictor step | `token[B,1]`, `state_m`, `state_c` | `pred_out`, `new_m`, `new_c` |
+| `joint.onnx` | RNN-T joint | `enc_t[B,1,E]`, `pred[B,1,P]` | `logits[B,1,V]` |
+
+CMVN is baked into the encoder graph, so ONNX consumes raw 80-dim fbank features.
+
+## Export
+
+```bash
+# CTC model (non-streaming)
+python tools/export_onnx.py \
+    --checkpoint khanhld/chunkformer-ctc-large-vie --out-dir onnx_out/ctc
+
+# RNN-T model (non-streaming)
+python tools/export_onnx.py \
+    --checkpoint khanhld/chunkformer-rnnt-large-vie --out-dir onnx_out/rnnt
+
+# Streaming RNN-T model (cache-aware). chunk/left/right must be a configuration
+# the model was trained with (see the model's dynamic_chunk_sizes).
+python tools/export_onnx.py \
+    --checkpoint khanhld/chunkformer-rnnt-small-vie-stream-dct --streaming \
+    --chunk-size 8 --left-context 60 --right-context 0 --out-dir onnx_out/rnnt_stream
+```
+
+`--checkpoint` accepts a local directory or a Hugging Face Hub repo id. Add
+`--simplify` to run `onnxsim` on each graph.
+
+### Non-streaming limited-context (masked chunking)
+
+The non-streaming encoder also supports ChunkFormer's masked limited-context
+decoding (efficient long-form mode). Pass `--full-chunk-size` (>0) with
+`--full-left-context` / `--full-right-context` to bake a chunk configuration into
+`encoder_full.onnx` instead of full self-attention:
+
+```bash
+python tools/export_onnx.py \
+    --checkpoint khanhld/chunkformer-ctc-large-vie \
+    --full-chunk-size 64 --full-left-context 128 --full-right-context 4 \
+    --out-dir onnx_out/ctc_limited
+```
+
+The time dimension stays dynamic, so one graph handles variable-length audio.
+`--full-chunk-size 0` (default) keeps full-context self-attention.
+
+## Inference
+
+```python
+import numpy as np
+from chunkformer.chunkformer_model import ChunkFormerModel
+from chunkformer.onnx.runtime import OnnxAsrModel
+
+# char_dict (id -> token) for text output; reuse the PyTorch model's table
+pt = ChunkFormerModel.from_pretrained("khanhld/chunkformer-ctc-large-vie")
+feats, flen = pt._load_audio_and_extract_features("samples/audios/audio_1.wav")
+
+onnx = OnnxAsrModel("onnx_out/ctc", device="cpu", char_dict=pt.char_dict)
+text = onnx.transcribe(
+    feats.unsqueeze(0).numpy(), np.array([flen], dtype=np.int64), streaming=False
+)
+print(text)
+```
+
+For a streaming model, pass `streaming=True` (the runtime runs the cache-aware
+chunk loop using the parameters stored in `onnx_config.json`).
+
+## Verify parity
+
+`tools/verify_onnx_parity.py` reports the max absolute difference between each
+PyTorch op and its ONNX counterpart, plus the decoded transcript from both:
+
+```bash
+python tools/verify_onnx_parity.py --all --audio samples/audios/audio_1.wav
+```
+
+Reference results (CPU, fp32, opset 17) on `audio_1.wav`:
+
+| Model | encoder_full | ctc | predictor | joint | encoder_chunk | text match |
+|---|---|---|---|---|---|---|
+| `chunkformer-ctc-large-vie` | 4.5e-6 | 1.5e-5 | - | - | - | yes |
+| `chunkformer-rnnt-large-vie` | 1.7e-6 | 9.5e-6 | 7.2e-7 | 4.8e-6 | - | yes |
+| `chunkformer-rnnt-small-vie-stream-dct` | 3.3e-6 | 1.9e-5 | 1.4e-6 | 5.7e-6 | 6.9e-6 | yes |
+
+All differences are at float32 numerical-noise level and transcripts match
+exactly between PyTorch and ONNX.
+
+## Notes / limitations
+
+- The attention (AED) decoder is **not** exported; CTC and RNN-T greedy decoding
+  are supported. Beam search / attention rescoring remain PyTorch-only.
+- The exporter uses the legacy TorchScript exporter (`dynamo=False`). Two ops are
+  ONNX-incompatible in their native form and are transparently rewritten only
+  during export (guarded by `torch.onnx.is_in_onnx_export()`), leaving eager
+  training/inference unchanged:
+  - relative-attention `rel_shift` (`as_strided` -> gather);
+  - chunking windows in limited-context attention and dynamic-conv
+    (`Tensor.unfold` -> gather / unsqueeze, via `chunkformer.utils.mask.onnx_unfold`).
+- Streaming `--chunk-size/--left-context/--right-context` must match a
+  configuration the model was trained with.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,11 @@ keywords = [
 ]
 
 [project.optional-dependencies]
+onnx = [
+    "onnx>=1.15.0",
+    "onnxruntime>=1.17.0",
+    "onnxsim>=0.4.0",
+]
 dev = [
     "pytest>=6.0.0",
     "black==25.9.0",

--- a/tests/test_onnx_op_rewrites.py
+++ b/tests/test_onnx_op_rewrites.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Exactness tests for the ONNX-safe op rewrites used during export.
+
+Two native ops are not representable by the (legacy) ONNX exporter and are
+transparently rewritten when ``torch.onnx.is_in_onnx_export()`` is true:
+
+* ``Tensor.unfold(dim, size, step)`` -> ``chunkformer.utils.mask.onnx_unfold``
+  (gather based), used by limited-context attention and dynamic convolution.
+* relative-attention ``rel_shift`` ``as_strided`` -> a ``torch.gather`` based
+  shift in ``ChunkAttentionWithRelativeRightContext.rel_shift``.
+
+These tests assert the rewritten ops produce *bit-identical* results to the
+native ops across the shapes/dtypes/contexts actually exercised by the model.
+"""
+
+from unittest import mock
+
+import pytest
+import torch
+
+from chunkformer.modules.attention import ChunkAttentionWithRelativeRightContext
+from chunkformer.utils.mask import onnx_unfold
+
+# ---------------------------------------------------------------------------
+# Tensor.unfold  ->  onnx_unfold
+# ---------------------------------------------------------------------------
+
+# (shape, dim, size, step) covering every call site in the model:
+#   attention: q  unfold(dim=1, chunk, chunk)
+#   attention: kv unfold(dim=2, l+c+r, chunk)
+#   attention: mask unfold(dim=-1, chunk, chunk) and (dim=-1, l+c+r, chunk)
+#   conv:      unfold(dim=-1, lorder+chunk, chunk)
+_UNFOLD_CASES = [
+    # (shape, dim, size, step, note)
+    ((2, 12, 4, 8), 1, 4, 4, "attn-q exact"),
+    ((2, 13, 4, 8), 1, 4, 4, "attn-q (needs trailing window dropped)"),
+    ((1, 4, 12, 16), 2, 6, 4, "attn-kv overlapping l+c+r"),
+    ((3, 1, 20), -1, 5, 5, "mask-q non-overlap"),
+    ((3, 1, 20), -1, 9, 5, "mask-kv overlap"),
+    ((2, 32, 24), -1, 9, 8, "conv lorder+chunk"),
+    ((1, 16, 8), -1, 8, 8, "single window (n=1)"),
+    ((1, 16, 9), 2, 9, 9, "single window exact fit"),
+    ((4, 7, 5, 40), -1, 7, 3, "4d last-dim overlap"),
+    ((2, 3, 4, 50), 3, 11, 7, "4d explicit positive dim"),
+]
+
+
+@pytest.mark.parametrize("shape,dim,size,step,note", _UNFOLD_CASES)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bool, torch.int64])
+def test_onnx_unfold_matches_native(shape, dim, size, step, note, dtype):
+    if dtype == torch.bool:
+        x = torch.rand(shape) > 0.5
+    elif dtype == torch.int64:
+        x = torch.randint(-50, 50, shape)
+    else:
+        x = torch.randn(shape)
+
+    native = x.unfold(dim, size, step)
+    rewritten = onnx_unfold(x, dim, size, step)
+
+    assert rewritten.shape == native.shape, f"{note}: shape {rewritten.shape} != {native.shape}"
+    assert rewritten.dtype == native.dtype, note
+    assert torch.equal(rewritten, native), f"{note}: values differ"
+
+
+def test_onnx_unfold_keeps_window_count_dynamic_symbolically():
+    """The number of windows must come from the data, not be baked as a constant
+    (this is what lets a single exported graph handle variable-length audio)."""
+    # Same (size, step) but different lengths -> different window counts, both OK.
+    for length, expected_n in [(20, 4), (40, 9), (8, 1)]:
+        x = torch.randn(2, 3, length)
+        out = onnx_unfold(x, -1, 8, 4)
+        assert out.shape == x.unfold(-1, 8, 4).shape
+        assert out.shape[2] == expected_n
+
+
+# ---------------------------------------------------------------------------
+# rel_shift:  as_strided  ->  gather
+# ---------------------------------------------------------------------------
+
+# (batch, head, time1, left_context, right_context). The relative-pos tensor
+# width must be n = 2*time1 - 1 + left + right (as produced by the model).
+_REL_SHIFT_CASES = [
+    (1, 4, 1, 0, 0),
+    (2, 8, 5, 0, 0),
+    (2, 4, 7, 3, 2),
+    (1, 2, 10, 6, 0),
+    (3, 4, 6, 0, 4),
+    (2, 8, 16, 8, 8),
+    (1, 1, 25, 12, 5),
+]
+
+
+def _make_attn(num_heads):
+    torch.manual_seed(0)
+    # n_feat must be divisible by num_heads; value is irrelevant for rel_shift.
+    return ChunkAttentionWithRelativeRightContext(num_heads, num_heads * 4, 0.0)
+
+
+@pytest.mark.parametrize("batch,head,time1,left,right", _REL_SHIFT_CASES)
+def test_rel_shift_gather_matches_as_strided(batch, head, time1, left, right):
+    attn = _make_attn(head)
+    n = 2 * time1 - 1 + left + right
+    x = torch.randn(batch, head, time1, n)
+
+    # Native (as_strided) branch.
+    native = attn.rel_shift(x, left, right)
+
+    # Force the ONNX/gather branch.
+    with mock.patch("torch.onnx.is_in_onnx_export", return_value=True):
+        rewritten = attn.rel_shift(x, left, right)
+
+    expected_time2 = time1 + left + right
+    assert native.shape == (batch, head, time1, expected_time2)
+    assert rewritten.shape == native.shape
+    assert torch.equal(rewritten, native), "gather rel_shift differs from as_strided"
+
+
+def test_rel_shift_formula_explicit():
+    """Spot-check the documented identity out[..., i, j] = x[..., i, (time1-1)-i+j]
+    on a tiny tensor with known values."""
+    attn = _make_attn(1)
+    time1, left, right = 3, 0, 0
+    n = 2 * time1 - 1 + left + right  # 5
+    x = torch.arange(time1 * n, dtype=torch.float32).view(1, 1, time1, n)
+
+    with mock.patch("torch.onnx.is_in_onnx_export", return_value=True):
+        out = attn.rel_shift(x, left, right)
+
+    time2 = time1 + left + right
+    ref = torch.empty(1, 1, time1, time2)
+    for i in range(time1):
+        for j in range(time2):
+            ref[0, 0, i, j] = x[0, 0, i, (time1 - 1) - i + j]
+    assert torch.equal(out, ref)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tools/export_onnx.py
+++ b/tools/export_onnx.py
@@ -32,7 +32,7 @@ Examples
 import argparse
 import json
 import os
-from typing import Dict
+from typing import Any, Dict
 
 import torch
 
@@ -100,7 +100,7 @@ def export_encoder_full(
 
 
 def export_encoder_chunk(
-    encoder: torch.nn.Module,
+    encoder: Any,
     feat_dim: int,
     chunk_size: int,
     left: int,
@@ -171,7 +171,7 @@ def export_ctc(ctc: torch.nn.Module, d_out: int, out_dir: str, simplify: bool):
         _maybe_simplify(path)
 
 
-def export_predictor(predictor: torch.nn.Module, out_dir: str, simplify: bool):
+def export_predictor(predictor: Any, out_dir: str, simplify: bool):
     wrapper = PredictorStepOnnx(predictor).eval()
     n_layers = predictor.n_layers
     hidden = predictor.hidden_size

--- a/tools/export_onnx.py
+++ b/tools/export_onnx.py
@@ -281,6 +281,11 @@ def main():
     )
     blank_id = int(getattr(inner, "blank", 0)) if is_transducer else 0
 
+    # Feature-extraction config so the ONNX runtime can go from waveform to
+    # fbank without loading the PyTorch model (CMVN is baked into the graph).
+    fbank_conf = getattr(hf_model.config, "fbank_conf", {}) or {}
+    resample_conf = getattr(hf_model.config, "resample_conf", {}) or {}
+
     meta: Dict[str, object] = {
         "model_type": model_type,
         "feat_dim": int(feat_dim),
@@ -296,7 +301,21 @@ def main():
         "is_transducer": bool(is_transducer),
         "streaming": bool(args.streaming),
         "opset": int(args.opset),
+        "feature": {
+            "sample_rate": int(resample_conf.get("resample_rate", 16000)),
+            "num_mel_bins": int(fbank_conf.get("num_mel_bins", feat_dim)),
+            "frame_length": int(fbank_conf.get("frame_length", 25)),
+            "frame_shift": int(fbank_conf.get("frame_shift", 10)),
+        },
     }
+
+    # Dump the vocabulary so text output needs no external files.
+    if hf_model.char_dict:
+        vocab_path = os.path.join(args.out_dir, "vocab.txt")
+        with open(vocab_path, "w", encoding="utf-8") as f:
+            for idx in sorted(hf_model.char_dict):
+                f.write(f"{hf_model.char_dict[idx]} {idx}\n")
+        print(f"  wrote {vocab_path}")
 
     if args.full_chunk_size > 0:
         print(

--- a/tools/export_onnx.py
+++ b/tools/export_onnx.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Export a ChunkFormer ASR model (CTC or RNN-T) to ONNX.
+
+Each network submodule is exported as a separate ONNX graph:
+
+- ``encoder_full.onnx``   full-context (non-streaming) encoder.
+- ``encoder_chunk.onnx``  cache-aware streaming encoder (``--streaming``).
+- ``ctc.onnx``            CTC head (if the model has one).
+- ``predictor.onnx``      RNN-T predictor step (transducer models).
+- ``joint.onnx``          RNN-T joint network (transducer models).
+
+Search / decoding loops stay in host Python (see ``chunkformer.onnx.runtime``).
+
+Examples
+--------
+    # CTC model, non-streaming
+    python tools/export_onnx.py \\
+        --checkpoint khanhld/chunkformer-ctc-large-vie --out-dir onnx/ctc
+
+    # RNN-T model, non-streaming
+    python tools/export_onnx.py \\
+        --checkpoint khanhld/chunkformer-rnnt-large-vie --out-dir onnx/rnnt
+
+    # Streaming RNN-T model (cache-aware)
+    python tools/export_onnx.py \\
+        --checkpoint khanhld/chunkformer-rnnt-small-vie-stream-dct --streaming \\
+        --chunk-size 64 --left-context 128 --right-context 8 --out-dir onnx/rnnt_stream
+
+``--checkpoint`` accepts a local directory or a Hugging Face Hub repo id.
+"""
+
+import argparse
+import json
+import os
+from typing import Dict
+
+import torch
+
+from chunkformer.chunkformer_model import ChunkFormerModel
+from chunkformer.onnx.wrappers import (
+    CtcOnnx,
+    EncoderChunkOnnx,
+    EncoderFullOnnx,
+    JointOnnx,
+    PredictorStepOnnx,
+)
+
+OPSET = 17
+
+
+def _maybe_simplify(path: str) -> None:
+    """Run onnxsim on a saved graph if the package is available."""
+    try:
+        import onnx
+        from onnxsim import simplify
+    except ImportError:
+        print("  (onnxsim not installed; skipping simplification)")
+        return
+    model = onnx.load(path)
+    model_simp, ok = simplify(model)
+    if ok:
+        onnx.save(model_simp, path)
+        print("  simplified")
+    else:
+        print("  simplification failed; keeping original")
+
+
+def export_encoder_full(
+    encoder: torch.nn.Module,
+    feat_dim: int,
+    out_dir: str,
+    simplify: bool,
+    chunk_size: int = 0,
+    left: int = 0,
+    right: int = 0,
+):
+    wrapper = EncoderFullOnnx(encoder, chunk_size, left, right).eval()
+    feats = torch.randn(1, 400, feat_dim)
+    feat_lens = torch.tensor([400], dtype=torch.int64)
+    path = os.path.join(out_dir, "encoder_full.onnx")
+    torch.onnx.export(
+        wrapper,
+        (feats, feat_lens),
+        path,
+        input_names=["feats", "feat_lens"],
+        output_names=["enc_out", "enc_lens"],
+        dynamic_axes={
+            "feats": {0: "batch", 1: "time"},
+            "feat_lens": {0: "batch"},
+            "enc_out": {0: "batch", 1: "out_time"},
+            "enc_lens": {0: "batch"},
+        },
+        opset_version=OPSET,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    print(f"  wrote {path}")
+    if simplify:
+        _maybe_simplify(path)
+
+
+def export_encoder_chunk(
+    encoder: torch.nn.Module,
+    feat_dim: int,
+    chunk_size: int,
+    left: int,
+    right: int,
+    out_dir: str,
+    simplify: bool,
+) -> Dict[str, int]:
+    sub = encoder.embed.subsampling_rate
+    heads = encoder.attention_heads
+    num_blocks = encoder.num_blocks
+    d_out = encoder.output_size()
+    conv_lorder = encoder.cnn_module_kernel // 2
+
+    size = encoder.embed.reverse_calc_length(chunk_size) + right * sub
+    stride = chunk_size * sub
+
+    wrapper = EncoderChunkOnnx(encoder, chunk_size, left, right).eval()
+    chunk = torch.randn(1, size, feat_dim)
+    att_cache = torch.zeros(num_blocks, 1, heads, left, d_out // heads * 2)
+    cnn_cache = torch.zeros(num_blocks, 1, d_out, conv_lorder)
+    offset = torch.zeros((), dtype=torch.int64)
+
+    path = os.path.join(out_dir, "encoder_chunk.onnx")
+    torch.onnx.export(
+        wrapper,
+        (chunk, att_cache, cnn_cache, offset),
+        path,
+        input_names=["chunk", "att_cache", "cnn_cache", "offset"],
+        output_names=["enc_out", "r_att_cache", "r_cnn_cache"],
+        dynamic_axes={
+            "chunk": {0: "batch", 1: "chunk_time"},
+            "att_cache": {1: "batch"},
+            "cnn_cache": {1: "batch"},
+            "enc_out": {0: "batch", 1: "out_time"},
+            "r_att_cache": {1: "batch"},
+            "r_cnn_cache": {1: "batch"},
+        },
+        opset_version=OPSET,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    print(f"  wrote {path}")
+    if simplify:
+        _maybe_simplify(path)
+    return {"size": int(size), "stride": int(stride)}
+
+
+def export_ctc(ctc: torch.nn.Module, d_out: int, out_dir: str, simplify: bool):
+    wrapper = CtcOnnx(ctc).eval()
+    enc_out = torch.randn(1, 50, d_out)
+    path = os.path.join(out_dir, "ctc.onnx")
+    torch.onnx.export(
+        wrapper,
+        (enc_out,),
+        path,
+        input_names=["enc_out"],
+        output_names=["log_probs"],
+        dynamic_axes={
+            "enc_out": {0: "batch", 1: "time"},
+            "log_probs": {0: "batch", 1: "time"},
+        },
+        opset_version=OPSET,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    print(f"  wrote {path}")
+    if simplify:
+        _maybe_simplify(path)
+
+
+def export_predictor(predictor: torch.nn.Module, out_dir: str, simplify: bool):
+    wrapper = PredictorStepOnnx(predictor).eval()
+    n_layers = predictor.n_layers
+    hidden = predictor.hidden_size
+    token = torch.zeros(1, 1, dtype=torch.int64)
+    state_m = torch.zeros(n_layers, 1, hidden)
+    state_c = torch.zeros(n_layers, 1, hidden)
+    path = os.path.join(out_dir, "predictor.onnx")
+    torch.onnx.export(
+        wrapper,
+        (token, state_m, state_c),
+        path,
+        input_names=["token", "state_m", "state_c"],
+        output_names=["pred_out", "new_m", "new_c"],
+        dynamic_axes={
+            "token": {0: "batch"},
+            "state_m": {1: "batch"},
+            "state_c": {1: "batch"},
+            "pred_out": {0: "batch"},
+            "new_m": {1: "batch"},
+            "new_c": {1: "batch"},
+        },
+        opset_version=OPSET,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    print(f"  wrote {path}")
+    if simplify:
+        _maybe_simplify(path)
+
+
+def export_joint(joint: torch.nn.Module, enc_dim: int, pred_dim: int, out_dir: str, simplify: bool):
+    wrapper = JointOnnx(joint).eval()
+    enc_t = torch.randn(1, 1, enc_dim)
+    pred = torch.randn(1, 1, pred_dim)
+    path = os.path.join(out_dir, "joint.onnx")
+    torch.onnx.export(
+        wrapper,
+        (enc_t, pred),
+        path,
+        input_names=["enc_t", "pred"],
+        output_names=["logits"],
+        dynamic_axes={
+            "enc_t": {0: "batch"},
+            "pred": {0: "batch"},
+            "logits": {0: "batch"},
+        },
+        opset_version=OPSET,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    print(f"  wrote {path}")
+    if simplify:
+        _maybe_simplify(path)
+
+
+@torch.no_grad()
+def main():
+    global OPSET
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--checkpoint", required=True, help="Local dir or HF repo id of the ChunkFormer model"
+    )
+    parser.add_argument("--out-dir", required=True, help="Output directory for the ONNX graphs")
+    parser.add_argument(
+        "--streaming",
+        action="store_true",
+        help="Also export the cache-aware streaming chunk encoder",
+    )
+    parser.add_argument("--chunk-size", type=int, default=64, help="Streaming chunk size (frames)")
+    parser.add_argument("--left-context", type=int, default=128, help="Streaming left context")
+    parser.add_argument("--right-context", type=int, default=8, help="Streaming right context")
+    parser.add_argument(
+        "--full-chunk-size",
+        type=int,
+        default=0,
+        help="Limited-context chunk size for the non-streaming encoder (0 = full context)",
+    )
+    parser.add_argument(
+        "--full-left-context", type=int, default=0, help="Non-streaming limited left context"
+    )
+    parser.add_argument(
+        "--full-right-context", type=int, default=0, help="Non-streaming limited right context"
+    )
+    parser.add_argument("--opset", type=int, default=OPSET, help="ONNX opset version")
+    parser.add_argument("--simplify", action="store_true", help="Run onnxsim on each graph")
+    args = parser.parse_args()
+
+    OPSET = args.opset
+
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    print(f"Loading checkpoint: {args.checkpoint}")
+    hf_model = ChunkFormerModel.from_pretrained(args.checkpoint)
+    hf_model.eval()
+    inner = hf_model.model
+    model_type = getattr(hf_model.config, "model", "asr_model")
+    encoder = inner.encoder
+    feat_dim = encoder.input_size
+    d_out = encoder.output_size()
+    has_ctc = getattr(inner, "ctc", None) is not None
+    is_transducer = model_type == "transducer"
+
+    vocab_size = (
+        len(hf_model.char_dict) if hf_model.char_dict else getattr(hf_model.config, "output_dim", 0)
+    )
+    blank_id = int(getattr(inner, "blank", 0)) if is_transducer else 0
+
+    meta: Dict[str, object] = {
+        "model_type": model_type,
+        "feat_dim": int(feat_dim),
+        "encoder_output_size": int(d_out),
+        "attention_heads": int(encoder.attention_heads),
+        "num_blocks": int(encoder.num_blocks),
+        "subsampling_rate": int(encoder.embed.subsampling_rate),
+        "cnn_module_kernel": int(encoder.cnn_module_kernel),
+        "cnn_lorder": int(encoder.cnn_module_kernel // 2),
+        "vocab_size": int(vocab_size),
+        "blank_id": int(blank_id),
+        "has_ctc": bool(has_ctc),
+        "is_transducer": bool(is_transducer),
+        "streaming": bool(args.streaming),
+        "opset": int(args.opset),
+    }
+
+    if args.full_chunk_size > 0:
+        print(
+            f"Exporting non-streaming encoder (limited context "
+            f"chunk={args.full_chunk_size} left={args.full_left_context} "
+            f"right={args.full_right_context})..."
+        )
+        meta["full_context"] = {
+            "chunk_size": int(args.full_chunk_size),
+            "left_context_size": int(args.full_left_context),
+            "right_context_size": int(args.full_right_context),
+        }
+    else:
+        print("Exporting full-context encoder...")
+    export_encoder_full(
+        encoder,
+        feat_dim,
+        args.out_dir,
+        args.simplify,
+        chunk_size=args.full_chunk_size,
+        left=args.full_left_context,
+        right=args.full_right_context,
+    )
+
+    if args.streaming:
+        print("Exporting streaming chunk encoder...")
+        stream_meta = export_encoder_chunk(
+            encoder,
+            feat_dim,
+            args.chunk_size,
+            args.left_context,
+            args.right_context,
+            args.out_dir,
+            args.simplify,
+        )
+        meta["stream"] = {
+            "chunk_size": int(args.chunk_size),
+            "left_context_size": int(args.left_context),
+            "right_context_size": int(args.right_context),
+            **stream_meta,
+        }
+
+    if has_ctc:
+        print("Exporting CTC head...")
+        export_ctc(inner.ctc, d_out, args.out_dir, args.simplify)
+
+    if is_transducer:
+        print("Exporting RNN-T predictor...")
+        export_predictor(inner.predictor, args.out_dir, args.simplify)
+        print("Exporting RNN-T joint...")
+        export_joint(inner.joint, d_out, inner.predictor.output_size(), args.out_dir, args.simplify)
+        meta["predictor"] = {
+            "n_layers": int(inner.predictor.n_layers),
+            "hidden_size": int(inner.predictor.hidden_size),
+            "output_size": int(inner.predictor.output_size()),
+        }
+
+    meta_path = os.path.join(args.out_dir, "onnx_config.json")
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(meta, f, indent=2)
+    print(f"Wrote metadata: {meta_path}")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/verify_onnx_parity.py
+++ b/tools/verify_onnx_parity.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Compare exported ONNX graphs against the PyTorch ChunkFormer model.
+
+For each module it reports the maximum absolute numerical difference between the
+PyTorch op and its ONNX Runtime counterpart (fed identical inputs), and it prints
+the final decoded transcript from both backends.
+
+Examples
+--------
+    # Single model
+    python tools/verify_onnx_parity.py \\
+        --checkpoint khanhld/chunkformer-ctc-large-vie \\
+        --onnx-dir onnx_out/ctc --audio samples/audios/audio_1.wav
+
+    # All three reference checkpoints (expects onnx_out/{ctc,rnnt,rnnt_stream})
+    python tools/verify_onnx_parity.py --all --audio samples/audios/audio_1.wav
+"""
+
+import argparse
+from typing import List
+
+import numpy as np
+import torch
+
+from chunkformer.chunkformer_model import ChunkFormerModel
+from chunkformer.onnx.runtime import OnnxAsrModel, remove_duplicates_and_blank
+from chunkformer.transducer.search.greedy_search import basic_greedy_search
+
+
+def _maxdiff(a: np.ndarray, b: np.ndarray) -> float:
+    n = min(a.shape[1], b.shape[1]) if a.ndim >= 2 else min(a.shape[0], b.shape[0])
+    if a.ndim >= 2:
+        a, b = a[:, :n], b[:, :n]
+    return float(np.max(np.abs(a.astype(np.float64) - b.astype(np.float64))))
+
+
+@torch.no_grad()
+def verify(checkpoint: str, onnx_dir: str, audio: str, device: str = "cpu") -> None:
+    print("=" * 78)
+    print(f"Checkpoint : {checkpoint}")
+    print(f"ONNX dir   : {onnx_dir}")
+    print(f"Audio      : {audio}")
+    print("-" * 78)
+
+    pt = ChunkFormerModel.from_pretrained(checkpoint)
+    pt.eval()
+    inner = pt.model
+    onnx = OnnxAsrModel(onnx_dir, device=device, char_dict=pt.char_dict)
+    is_transducer = onnx.meta.get("is_transducer", False)
+    streaming = onnx.meta.get("streaming", False)
+
+    feats, flen = pt._load_audio_and_extract_features(audio)
+    xs = feats.unsqueeze(0)
+    xs_lens = torch.tensor([flen], dtype=torch.int64)
+
+    # ---- 1. non-streaming encoder (full-context, or limited-context if baked)
+    fc = onnx.meta.get("full_context", {})
+    fc_chunk = fc.get("chunk_size", 0)
+    fc_left = fc.get("left_context_size", 0)
+    fc_right = fc.get("right_context_size", 0)
+    enc_pt, mask_pt = inner.encoder.forward_encoder(xs, xs_lens, fc_chunk, fc_left, fc_right)
+    enc_len_pt = int(mask_pt.squeeze(1).sum(1)[0])
+    enc_onnx, enc_lens_onnx = onnx.encode_full(xs.numpy(), xs_lens.numpy())
+    ctx = "full" if fc_chunk == 0 else f"chunk={fc_chunk} l={fc_left} r={fc_right}"
+    print(
+        f"[encoder_full]  ({ctx})  out shape {tuple(enc_pt.shape)}  "
+        f"len pt={enc_len_pt} onnx={int(enc_lens_onnx[0])}  "
+        f"max|diff|={_maxdiff(enc_pt.numpy(), enc_onnx):.3e}"
+    )
+
+    # ---- 2. CTC head (feed identical PyTorch encoder output)
+    if onnx.ctc is not None:
+        ctc_pt = inner.ctc.log_softmax(enc_pt).numpy()
+        ctc_onnx = onnx.ctc_logprobs(enc_pt.numpy())
+        print(
+            f"[ctc]           out shape {ctc_pt.shape[1:]}  "
+            f"max|diff|={_maxdiff(ctc_pt, ctc_onnx):.3e}"
+        )
+
+    # ---- 3 & 4. RNN-T predictor + joint
+    if is_transducer:
+        assert onnx.predictor is not None and onnx.joint is not None
+        n_layers = onnx.meta["predictor"]["n_layers"]
+        hidden = onnx.meta["predictor"]["hidden_size"]
+        token = torch.zeros(1, 1, dtype=torch.int64)
+        m = torch.zeros(n_layers, 1, hidden)
+        c = torch.zeros(n_layers, 1, hidden)
+        pred_pt, (nm_pt, nc_pt) = inner.predictor.forward_step(token, [m, c])
+        pred_onnx, nm_onnx, nc_onnx = onnx.predictor.run(
+            ["pred_out", "new_m", "new_c"],
+            {"token": token.numpy(), "state_m": m.numpy(), "state_c": c.numpy()},
+        )
+        print(
+            f"[predictor]     out shape {tuple(pred_pt.shape)}  "
+            f"max|diff|={_maxdiff(pred_pt.numpy(), pred_onnx):.3e}"
+        )
+
+        enc_t = enc_pt[:, :1, :]
+        joint_pt = inner.joint(enc_t, pred_pt).numpy()
+        (joint_onnx,) = onnx.joint.run(
+            ["logits"], {"enc_t": enc_t.numpy(), "pred": pred_pt.numpy()}
+        )
+        print(
+            f"[joint]         out shape {joint_pt.shape[1:]}  "
+            f"max|diff|={_maxdiff(joint_pt, joint_onnx):.3e}"
+        )
+
+    # ---- 5. streaming chunk encoder
+    if streaming and onnx.encoder_chunk is not None:
+        s = onnx.meta["stream"]
+        enc_stream_pt, mask_s = inner.encoder.forward_chunk_by_chunk(
+            xs, xs_lens, s["chunk_size"], s["left_context_size"], s["right_context_size"]
+        )
+        enc_stream_onnx = onnx.encode_streaming(xs.numpy())
+        print(
+            f"[encoder_chunk] out shape {tuple(enc_stream_pt.shape)} (pt) / "
+            f"{enc_stream_onnx.shape} (onnx)  "
+            f"max|diff|={_maxdiff(enc_stream_pt.numpy(), enc_stream_onnx):.3e}"
+        )
+
+    # ---- text output
+    pt_tokens = _pt_tokens(inner, enc_pt, enc_len_pt, is_transducer, onnx.blank_id)
+    pt_text = onnx.tokens_to_text(pt_tokens)
+    onnx_text = onnx.transcribe(xs.numpy(), xs_lens.numpy(), streaming=False)
+    print("-" * 78)
+    print(f"PyTorch text : {pt_text}")
+    print(f"ONNX text    : {onnx_text}")
+    print(f"Text match   : {pt_text == onnx_text}")
+    if streaming and onnx.encoder_chunk is not None:
+        onnx_stream_text = onnx.transcribe(xs.numpy(), xs_lens.numpy(), streaming=True)
+        print(f"ONNX (stream): {onnx_stream_text}")
+    print("=" * 78)
+    print()
+
+
+def _pt_tokens(
+    inner, enc_pt: torch.Tensor, enc_len: int, is_transducer: bool, blank_id: int
+) -> List[int]:
+    if is_transducer:
+        return basic_greedy_search(inner, enc_pt, torch.tensor(enc_len))[0]
+    log_probs = inner.ctc.log_softmax(enc_pt)[0][:enc_len]
+    hyp = log_probs.argmax(dim=-1).tolist()
+    return remove_duplicates_and_blank(hyp, blank_id)
+
+
+REFERENCE = [
+    ("khanhld/chunkformer-ctc-large-vie", "onnx_out/ctc"),
+    ("khanhld/chunkformer-rnnt-large-vie", "onnx_out/rnnt"),
+    ("khanhld/chunkformer-rnnt-small-vie-stream-dct", "onnx_out/rnnt_stream"),
+]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--checkpoint", help="Local dir or HF repo id of the model")
+    parser.add_argument("--onnx-dir", help="Directory with the exported ONNX graphs")
+    parser.add_argument("--audio", default="samples/audios/audio_1.wav", help="Sample audio path")
+    parser.add_argument("--device", default="cpu", choices=["cpu", "cuda"])
+    parser.add_argument("--all", action="store_true", help="Run the 3 reference checkpoints")
+    args = parser.parse_args()
+
+    if args.all:
+        for ckpt, d in REFERENCE:
+            verify(ckpt, d, args.audio, args.device)
+    else:
+        if not args.checkpoint or not args.onnx_dir:
+            parser.error("--checkpoint and --onnx-dir are required unless --all is given")
+        verify(args.checkpoint, args.onnx_dir, args.audio, args.device)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/verify_streaming_session.py
+++ b/tools/verify_streaming_session.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Verify the online StreamingSession against the offline streaming path.
+
+Checks, for a --streaming export:
+  1. online fbank (push_waveform in random-sized chunks) == offline extract_features
+  2. streaming-session transcript matches OnnxAsrModel.transcribe(streaming=True)
+  3. the CTC-only streaming path (encoder cache only) also runs and matches its
+     own offline CTC streaming decode.
+"""
+
+import argparse
+
+import numpy as np
+from pydub import AudioSegment
+
+from chunkformer.onnx.runtime import OnnxAsrModel
+
+
+def load_int16_samples(path: str, sr: int) -> np.ndarray:
+    audio = AudioSegment.from_file(path).set_frame_rate(sr).set_sample_width(2).set_channels(1)
+    return np.array(audio.get_array_of_samples(), dtype=np.float32)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--onnx-dir", required=True)
+    ap.add_argument("--audio", required=True)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    m = OnnxAsrModel(args.onnx_dir)
+    sr = m.meta["feature"]["sample_rate"]
+    samples = load_int16_samples(args.audio, sr)
+
+    # 1) online vs offline fbank ------------------------------------------------
+    offline_feats = m.extract_features(args.audio)[0]  # (T, F)
+    sess = m.stream()
+    rng = np.random.default_rng(args.seed)
+    online_frames = []
+    i = 0
+    while i < len(samples):
+        n = int(rng.integers(800, 5000))
+        sess.push_features  # noqa: B018  (touch to keep linters calm)
+        chunk = samples[i : i + n]
+        feats = sess._samples_to_features(chunk)  # noqa: SLF001 - test introspection
+        if feats.shape[0]:
+            online_frames.append(feats)
+        i += n
+    online_feats = np.concatenate(online_frames, axis=0)
+    n = min(len(offline_feats), len(online_feats))
+    feat_diff = float(np.abs(offline_feats[:n] - online_feats[:n]).max())
+    print(
+        f"[fbank]   offline {offline_feats.shape} online {online_feats.shape} "
+        f"max|diff|={feat_diff:.3e}"
+    )
+    assert online_feats.shape[0] == offline_feats.shape[0], "frame count differs"
+    assert feat_diff < 1e-3, "online fbank differs from offline"
+
+    # 2) streaming-session transcript vs offline streaming ----------------------
+    offline_text = m.transcribe_file(args.audio, streaming=True)
+
+    sess = m.stream()
+    delta_parts = []
+    i = 0
+    while i < len(samples):
+        n = int(rng.integers(1600, 8000))  # ~0.1-0.5s chunks
+        d = sess.push_waveform(samples[i : i + n])
+        if d:
+            delta_parts.append(d)
+        i += n
+    d = sess.finalize()
+    if d:
+        delta_parts.append(d)
+    stream_text = sess.text
+
+    print(f"\n[offline stream] {offline_text}")
+    print(f"[online  stream] {stream_text}")
+    print(f"[delta concat  ] {''.join(delta_parts)}")
+    print(f"transcript match: {stream_text == offline_text}")
+
+    # 3) CTC-only streaming path (encoder cache only) ---------------------------
+    if m.ctc is not None:
+        cs = m.stream()
+        cs.is_transducer = False  # force the CTC decode branch (encoder cache only)
+        i = 0
+        while i < len(samples):
+            n = int(rng.integers(1600, 8000))
+            cs.push_waveform(samples[i : i + n])
+            i += n
+        cs.finalize()
+        # offline CTC streaming reference
+        enc = m.encode_streaming(m.extract_features(args.audio))
+        ref = m.tokens_to_text(m.ctc_greedy(enc, enc.shape[1]))
+        print(f"\n[ctc offline   ] {ref}")
+        print(f"[ctc online    ] {cs.text}")
+        print(f"ctc match: {cs.text == ref}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add ONNX export + ONNX Runtime inference for ChunkFormer ASR models:
- chunkformer/onnx/wrappers.py: ONNX-clean wrappers for full-context and cache-aware streaming encoders, CTC head, RNN-T predictor step and joint.
- chunkformer/onnx/runtime.py: OnnxAsrModel host runtime (CTC + RNN-T greedy, streaming chunk loop).
- tools/export_onnx.py: per-submodule exporter (CTC/RNN-T, streaming via --streaming, non-stream limited-context via --full-chunk-size/left/right).
- tools/verify_onnx_parity.py: PyTorch-vs-ONNX module diff + transcript report.
- examples/onnx/README.md, [onnx] extra in pyproject, onnx_out/ gitignored.

ONNX-incompatible ops are rewritten only during export (guarded by is_in_onnx_export), leaving eager training/inference unchanged:
- attention rel_shift as_strided -> gather;
- Tensor.unfold -> gather/unsqueeze (utils.mask.onnx_unfold) in limited-context attention and dynamic conv.

Verified parity on chunkformer-ctc-large-vie, chunkformer-rnnt-large-vie and chunkformer-rnnt-small-vie-stream-dct: all module diffs <=2e-5 and transcripts match exactly (full-context, limited-context and streaming).